### PR TITLE
FIX: Add support for proxyPort option to correct JSON links when behind a PaaS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-
-## [0.3.3] - 2021-03-28
+## [0.3.2] - 2021-03-28
 ### Changed
 - Add proxyPort config support to fix links behind a PaaS
-
-## [0.3.2] - 2020-02-15
-### Changed
 - Bumped dev dependencies
 - Updated (major) json-api-serializer dependency to v2.3.0
 - Updated (major) pluralize dependency to v8.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+## [0.3.3] - 2021-03-28
+### Changed
+- Add proxyPort config support to fix links behind a PaaS
+
 ## [0.3.2] - 2020-02-15
 ### Changed
 - Bumped dev dependencies

--- a/lib/helpers/generate-resource-link.js
+++ b/lib/helpers/generate-resource-link.js
@@ -22,7 +22,7 @@ module.exports = {
     const isSsl = (sails.config.ssl && sails.config.ssl.key && sails.config.ssl.cert) || sails.config.proxyHostSsl;
     const protocol = isSsl ? 'https' : 'http';
     const host = sails.config.explicitHost || sails.config.proxyHost || 'localhost';
-    const port = sails.config.port || (isSsl ? 443 : 80);
+    const port = sails.config.proxyPort || sails.config.port || (isSsl ? 443 : 80);
     const linkPrefix = sails.config.blueprints.linkPrefix ? sails.config.blueprints.linkPrefix : '';
 
     return exits.success(


### PR DESCRIPTION
-sails.config.proxyPort now overrides the default sails.config.port option when generating resource links. sails.config.port is likely bound to a network-internal port when operating on a PaaS.